### PR TITLE
Add .gitattributes to get CRLF right under Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+#Which files need CRLF handling
+# Default is auto
+* text=auto
+
+# But we can help Git, because we now about some file extensions
+*.bat  text eol=crlf
+*.cmd  -text
+*.gif  -text
+*.opi  -text
+*.png  -text
+*.ppt* -text  
+*.py   text eol=lf
+*.sh   text eol=lf


### PR DESCRIPTION
Make sure that files get CRLF under Windows, if needed, when
files are checked out.
Make sure that files with CRLF are commited with LF, if needed.