### PR TITLE
Added an example IOC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-/configure
-/dbd
-/lib
+bin
+dbd
+lib
 O.*
 *.pyc
+envPaths

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,27 @@
-# Makefile at top of application tree
+#Makefile at top of application tree
 TOP = .
 include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), configure)
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Support))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *App))
+ifeq ($(BUILD_IOCS), YES)
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard iocs))
+iocs_DEPEND_DIRS += vmcApp
+endif
 
-# Directories to build, any order
-DIRS += configure
-DIRS += $(wildcard *Sup)
-DIRS += $(wildcard *App)
-DIRS += $(wildcard *Top)
-DIRS += $(wildcard iocBoot)
-
-# The build order is controlled by these dependency rules:
-
-# All dirs except configure depend on configure
-$(foreach dir, $(filter-out configure, $(DIRS)), \
-    $(eval $(dir)_DEPEND_DIRS += configure))
-
-# Any *App dirs depend on all *Sup dirs
-$(foreach dir, $(filter %App, $(DIRS)), \
-    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup, $(DIRS))))
-
-# Any *Top dirs depend on all *Sup and *App dirs
-$(foreach dir, $(filter %Top, $(DIRS)), \
-    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup %App, $(DIRS))))
-
-# iocBoot depends on all *App dirs
-iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
-
-# Add any additional dependency rules here:
+define DIR_template
+ $(1)_DEPEND_DIRS = configure
+endef
+$(foreach dir, $(filter-out configure,$(DIRS)),$(eval $(call DIR_template,$(dir))))
 
 include $(TOP)/configure/RULES_TOP
+
+uninstall: uninstall_iocs
+uninstall_iocs:
+	$(MAKE) -C iocs uninstall
+.PHONY: uninstall uninstall_iocs
+
+realuninstall: realuninstall_iocs
+realuninstall_iocs:
+	$(MAKE) -C iocs realuninstall
+.PHONY: realuninstall realuninstall_iocs

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -35,6 +35,9 @@ CHECK_RELEASE = YES
 #HOST_OPT = NO
 #CROSS_OPT = NO
 
+# Build IOC by default
+BUILD_IOCS = YES
+
 # These allow developers to override the CONFIG_SITE variable
 # settings without having to modify the configure/CONFIG_SITE
 # file itself.

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -23,7 +23,7 @@
 # the CONFIG_SITE file.
 
 # Variables and paths to dependent modules:
-MOTOR = /net/s100dserv/xorApps/epics/motor-devel/testing/pullreq36/motor
+MOTOR = /net/s100dserv/xorApps/epics/motor-devel/support/motor
 -include $(MOTOR)/configure/RELEASE
 
 # EPICS_BASE should appear last so earlier modules can override stuff:

--- a/iocs/Makefile
+++ b/iocs/Makefile
@@ -1,0 +1,25 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+
+DIRS += vmcIOC
+
+include $(TOP)/configure/RULES_TOP
+
+uninstallTargets = $(foreach dir, $(DIRS), $(dir)$(DIVIDER)uninstall)
+uninstall: $(uninstallTargets)
+define UNINSTALL_template
+$(1)$(DIVIDER)uninstall:
+	$(MAKE) -C $(1) uninstall
+endef
+$(foreach dir, $(DIRS), $(eval $(call UNINSTALL_template,$(dir))))
+.PHONY: uninstall $(uninstallTargets)
+
+realuninstallTargets = $(foreach dir, $(DIRS), $(dir)$(DIVIDER)realuninstall)
+realuninstall: $(realuninstallTargets)
+define REALUNINSTALL_template
+$(1)$(DIVIDER)realuninstall:
+	$(MAKE) -C $(1) realuninstall
+endef
+$(foreach dir, $(DIRS), $(eval $(call REALUNINSTALL_template,$(dir))))
+.PHONY: realuninstall $(realuninstallTargets)
+

--- a/iocs/vmcIOC/Makefile
+++ b/iocs/vmcIOC/Makefile
@@ -1,0 +1,31 @@
+# Makefile at top of application tree
+TOP = .
+include $(TOP)/configure/CONFIG
+
+# Directories to build, any order
+DIRS += configure
+DIRS += $(wildcard *Sup)
+DIRS += $(wildcard *App)
+DIRS += $(wildcard *Top)
+DIRS += $(wildcard iocBoot)
+
+# The build order is controlled by these dependency rules:
+
+# All dirs except configure depend on configure
+$(foreach dir, $(filter-out configure, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += configure))
+
+# Any *App dirs depend on all *Sup dirs
+$(foreach dir, $(filter %App, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup, $(DIRS))))
+
+# Any *Top dirs depend on all *Sup and *App dirs
+$(foreach dir, $(filter %Top, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %Sup %App, $(DIRS))))
+
+# iocBoot depends on all *App dirs
+iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
+
+# Add any additional dependency rules here:
+
+include $(TOP)/configure/RULES_TOP

--- a/iocs/vmcIOC/configure/CONFIG
+++ b/iocs/vmcIOC/configure/CONFIG
@@ -1,0 +1,29 @@
+# CONFIG - Load build configuration data
+#
+# Do not make changes to this file!
+
+# Allow user to override where the build rules come from
+RULES = $(EPICS_BASE)
+
+# RELEASE files point to other application tops
+include $(TOP)/configure/RELEASE
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+-include $(TOP)/configure/RELEASE.Common.$(T_A)
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+
+CONFIG = $(RULES)/configure
+include $(CONFIG)/CONFIG
+
+# Override the Base definition:
+INSTALL_LOCATION = $(TOP)
+
+# CONFIG_SITE files contain other build configuration settings
+include $(TOP)/configure/CONFIG_SITE
+-include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+ -include $(TOP)/configure/CONFIG_SITE.Common.$(T_A)
+ -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+

--- a/iocs/vmcIOC/configure/CONFIG_SITE
+++ b/iocs/vmcIOC/configure/CONFIG_SITE
@@ -1,0 +1,43 @@
+# CONFIG_SITE
+
+# Make any application-specific changes to the EPICS build
+#   configuration variables in this file.
+#
+# Host/target specific settings can be specified in files named
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+#   CONFIG_SITE.Common.$(T_A)
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+
+# CHECK_RELEASE controls the consistency checking of the support
+#   applications pointed to by the RELEASE* files.
+# Normally CHECK_RELEASE should be set to YES.
+# Set CHECK_RELEASE to NO to disable checking completely.
+# Set CHECK_RELEASE to WARN to perform consistency checking but
+#   continue building even if conflicts are found.
+CHECK_RELEASE = YES
+
+# Set this when you only want to compile this application
+#   for a subset of the cross-compiled target architectures
+#   that Base is built for.
+#CROSS_COMPILER_TARGET_ARCHS = vxWorks-ppc32
+
+# To install files into a location other than $(TOP) define
+#   INSTALL_LOCATION here.
+#INSTALL_LOCATION=</absolute/path/to/install/top>
+
+# Set this when the IOC and build host use different paths
+#   to the install location. This may be needed to boot from
+#   a Microsoft FTP server say, or on some NFS configurations.
+#IOCS_APPL_TOP = </IOC's/absolute/path/to/install/top>
+
+# For application debugging purposes, override the HOST_OPT and/
+#   or CROSS_OPT settings from base/configure/CONFIG_SITE
+#HOST_OPT = NO
+#CROSS_OPT = NO
+
+# These allow developers to override the CONFIG_SITE variable
+# settings without having to modify the configure/CONFIG_SITE
+# file itself.
+-include $(TOP)/../CONFIG_SITE.local
+-include $(TOP)/configure/CONFIG_SITE.local
+

--- a/iocs/vmcIOC/configure/Makefile
+++ b/iocs/vmcIOC/configure/Makefile
@@ -1,0 +1,8 @@
+TOP=..
+
+include $(TOP)/configure/CONFIG
+
+TARGETS = $(CONFIG_TARGETS)
+CONFIGS += $(subst ../,,$(wildcard $(CONFIG_INSTALLS)))
+
+include $(TOP)/configure/RULES

--- a/iocs/vmcIOC/configure/RELEASE
+++ b/iocs/vmcIOC/configure/RELEASE
@@ -25,9 +25,8 @@
 # Variables and paths to dependent modules:
 #MODULES = /path/to/modules
 #MYMODULE = $(MODULES)/my-module
-
-# If using the sequencer, point SNCSEQ at its top directory:
-#SNCSEQ = $(MODULES)/seq-ver
+MOTORVMC=$(TOP)/../..
+-include $(MOTORVMC)/configure/RELEASE
 
 # EPICS_BASE should appear last so earlier modules can override stuff:
 EPICS_BASE = /APSshare/epics/base-3.15.5

--- a/iocs/vmcIOC/configure/RELEASE
+++ b/iocs/vmcIOC/configure/RELEASE
@@ -1,0 +1,43 @@
+# RELEASE - Location of external support modules
+#
+# IF YOU MAKE ANY CHANGES to this file you must subsequently
+# do a "gnumake rebuild" in this application's top level
+# directory.
+#
+# The build process does not check dependencies against files
+# that are outside this application, thus you should do a
+# "gnumake rebuild" in the top level directory after EPICS_BASE
+# or any other external module pointed to below is rebuilt.
+#
+# Host- or target-specific settings can be given in files named
+#  RELEASE.$(EPICS_HOST_ARCH).Common
+#  RELEASE.Common.$(T_A)
+#  RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+#
+# This file is parsed by both GNUmake and an EPICS Perl script,
+# so it can ONLY contain definititions of paths to other support
+# modules, variable definitions that are used in module paths,
+# and include statements that pull in other RELEASE files.
+# Variables may be used before their values have been set.
+# Build variables that are NOT used in paths should be set in
+# the CONFIG_SITE file.
+
+# Variables and paths to dependent modules:
+#MODULES = /path/to/modules
+#MYMODULE = $(MODULES)/my-module
+
+# If using the sequencer, point SNCSEQ at its top directory:
+#SNCSEQ = $(MODULES)/seq-ver
+
+# EPICS_BASE should appear last so earlier modules can override stuff:
+EPICS_BASE = /APSshare/epics/base-3.15.5
+
+# Set RULES here if you want to use build rules from somewhere
+# other than EPICS_BASE:
+#RULES = $(MODULES)/build-rules
+
+# These allow developers to override the RELEASE variable settings
+# without having to modify the configure/RELEASE file itself.
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/configure/RELEASE.local
+

--- a/iocs/vmcIOC/configure/RULES
+++ b/iocs/vmcIOC/configure/RULES
@@ -1,0 +1,6 @@
+# RULES
+
+include $(CONFIG)/RULES
+
+# Library should be rebuilt because LIBOBJS may have changed.
+$(LIBNAME): ../Makefile

--- a/iocs/vmcIOC/configure/RULES.ioc
+++ b/iocs/vmcIOC/configure/RULES.ioc
@@ -1,0 +1,2 @@
+#RULES.ioc
+include $(CONFIG)/RULES.ioc

--- a/iocs/vmcIOC/configure/RULES_DIRS
+++ b/iocs/vmcIOC/configure/RULES_DIRS
@@ -1,0 +1,2 @@
+#RULES_DIRS
+include $(CONFIG)/RULES_DIRS

--- a/iocs/vmcIOC/configure/RULES_TOP
+++ b/iocs/vmcIOC/configure/RULES_TOP
@@ -1,0 +1,3 @@
+#RULES_TOP
+include $(CONFIG)/RULES_TOP
+

--- a/iocs/vmcIOC/iocBoot/Makefile
+++ b/iocs/vmcIOC/iocBoot/Makefile
@@ -1,0 +1,6 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS += $(wildcard *ioc*)
+DIRS += $(wildcard as*)
+include $(CONFIG)/RULES_DIRS
+

--- a/iocs/vmcIOC/iocBoot/iocvmc/Makefile
+++ b/iocs/vmcIOC/iocBoot/iocvmc/Makefile
@@ -1,0 +1,4 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+TARGETS = envPaths
+include $(TOP)/configure/RULES.ioc

--- a/iocs/vmcIOC/iocBoot/iocvmc/st.cmd
+++ b/iocs/vmcIOC/iocBoot/iocvmc/st.cmd
@@ -5,16 +5,15 @@
 
 < envPaths
 
-cd "${TOP}"
+cd "${TOP}/iocBoot/${IOC}"
 
 ## Register all support components
-dbLoadDatabase "dbd/vmc.dbd"
+dbLoadDatabase "$(TOP)/dbd/vmc.dbd"
 vmc_registerRecordDeviceDriver pdbbase
 
-## Load record instances
-#dbLoadRecords("db/xxx.db","user=kpetersn")
+#
+< vmc.cmd
 
-cd "${TOP}/iocBoot/${IOC}"
 iocInit
 
 ## Start any sequence programs

--- a/iocs/vmcIOC/iocBoot/iocvmc/st.cmd
+++ b/iocs/vmcIOC/iocBoot/iocvmc/st.cmd
@@ -1,0 +1,21 @@
+#!../../bin/linux-x86_64/vmc
+
+## You may have to change vmc to something else
+## everywhere it appears in this file
+
+< envPaths
+
+cd "${TOP}"
+
+## Register all support components
+dbLoadDatabase "dbd/vmc.dbd"
+vmc_registerRecordDeviceDriver pdbbase
+
+## Load record instances
+#dbLoadRecords("db/xxx.db","user=kpetersn")
+
+cd "${TOP}/iocBoot/${IOC}"
+iocInit
+
+## Start any sequence programs
+#seq sncxxx,"user=kpetersn"

--- a/iocs/vmcIOC/iocBoot/iocvmc/vmc.cmd
+++ b/iocs/vmcIOC/iocBoot/iocvmc/vmc.cmd
@@ -1,0 +1,42 @@
+### virtual motor controller support
+
+epicsEnvSet("PREFIX", "vmc:")
+epicsEnvSet("VMC_PORT1", "31337")
+
+drvAsynIPPortConfigure("VMC_ETH","127.0.0.1:$(VMC_PORT1)", 0, 0, 0)
+
+# Show communication
+#!asynSetTraceMask("VMC_ETH", 0, 3)
+# Only show errors
+asynSetTraceMask("VMC_ETH", 0, 1)
+# Leave ascii selected so traces can be turned on with a single click
+asynSetTraceIOMask("VMC_ETH", 0, 1)
+
+# Set end-of-string terminators
+asynOctetSetInputEos("VMC_ETH",0,"\r\n")
+asynOctetSetOutputEos("VMC_ETH",0,"\r")
+
+# These motor records can get their prefix from the environment variable
+dbLoadRecords("$(MOTOR)/motorApp/Db/asyn_motor.db","P=$(PREFIX),M=m1,DTYP=asynMotor,PORT=VMC1,ADDR=0,DESC=X,EGU=mm,DIR=Pos,VELO=1,VBAS=.1,ACCL=.2,BDST=0,BVEL=1,BACC=.2,MRES=.0025,PREC=4,DHLM=100,DLLM=-100,INIT=")
+dbLoadRecords("$(MOTOR)/motorApp/Db/asyn_motor.db","P=$(PREFIX),M=m2,DTYP=asynMotor,PORT=VMC1,ADDR=1,DESC=Y,EGU=mm,DIR=Pos,VELO=1,VBAS=.1,ACCL=.2,BDST=0,BVEL=1,BACC=.2,MRES=.0025,PREC=4,DHLM=100,DLLM=-100,INIT=")
+dbLoadRecords("$(MOTOR)/motorApp/Db/asyn_motor.db","P=$(PREFIX),M=m3,DTYP=asynMotor,PORT=VMC1,ADDR=2,DESC=Z,EGU=mm,DIR=Pos,VELO=1,VBAS=.1,ACCL=.2,BDST=0,BVEL=1,BACC=.2,MRES=.0025,PREC=4,DHLM=100,DLLM=-100,INIT=")
+# If a substitutions file is used, the "P" macro needs to be modified by hand
+#!dbLoadTemplate("templates/vmc.substitutions")
+
+# VirtualMotorController(
+#    portName          The name of the asyn port that will be created for this driver
+#    VirtualMotorPortName     The name of the drvAsynSerialPort that was created previously to connect to the VirtualMotor controller 
+#    numAxes           The number of axes that this controller supports 
+#    movingPollPeriod  The time between polls when any axis is moving 
+#    idlePollPeriod    The time between polls when no axis is moving 
+
+# 1-second idle polling
+VirtualMotorCreateController("VMC1", "VMC_ETH", 3, 250, 1000)
+# 10-second idle polling
+#!VirtualMotorCreateController("VMC1", "VMC_ETH", 3, 250, 10000)
+# No idle polling
+#!VirtualMotorCreateController("VMC1", "VMC_ETH", 3, 250, 0)
+# Extra axes, 10-second idle polling
+#!VirtualMotorCreateController("VMC1", "VMC_ETH", 8, 250, 10000)
+
+dbLoadRecords("$(ASYN)/db/asynRecord.db","P=$(PREFIX),R=asyn1,PORT=VMC_ETH,ADDR=0,OMAX=0,IMAX=0")

--- a/iocs/vmcIOC/vmcApp/Db/Makefile
+++ b/iocs/vmcIOC/vmcApp/Db/Makefile
@@ -1,0 +1,22 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/iocs/vmcIOC/vmcApp/Makefile
+++ b/iocs/vmcIOC/vmcApp/Makefile
@@ -1,0 +1,8 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/iocs/vmcIOC/vmcApp/src/Makefile
+++ b/iocs/vmcIOC/vmcApp/src/Makefile
@@ -16,10 +16,16 @@ DBD += vmc.dbd
 vmc_DBD += base.dbd
 
 # Include dbd files from all support applications:
-#vmc_DBD += xxx.dbd
+vmc_DBD += motorSupport.dbd
+vmc_DBD += vmc.dbd
 
 # Add all the support libraries needed by this IOC
 #vmc_LIBS += xxx
+vmc_LIBS += motor
+vmc_LIBS += vmc
+#!vmc_LIBS += softMotor
+#!vmc_LIBS += motorSimSupport
+#!vmc_LIBS += 
 
 # vmc_registerRecordDeviceDriver.cpp derives from vmc.dbd
 vmc_SRCS += vmc_registerRecordDeviceDriver.cpp

--- a/iocs/vmcIOC/vmcApp/src/Makefile
+++ b/iocs/vmcIOC/vmcApp/src/Makefile
@@ -1,0 +1,42 @@
+TOP=../..
+
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+#=============================
+
+#=============================
+# Build the IOC application
+
+PROD_IOC = vmc
+# vmc.dbd will be created and installed
+DBD += vmc.dbd
+
+# vmc.dbd will be made up from these files:
+vmc_DBD += base.dbd
+
+# Include dbd files from all support applications:
+#vmc_DBD += xxx.dbd
+
+# Add all the support libraries needed by this IOC
+#vmc_LIBS += xxx
+
+# vmc_registerRecordDeviceDriver.cpp derives from vmc.dbd
+vmc_SRCS += vmc_registerRecordDeviceDriver.cpp
+
+# Build the main IOC entry point on workstation OSs.
+vmc_SRCS_DEFAULT += vmcMain.cpp
+vmc_SRCS_vxWorks += -nil-
+
+# Add support from base/src/vxWorks if needed
+#vmc_OBJS_vxWorks += $(EPICS_BASE_BIN)/vxComLibrary
+
+# Finally link to the EPICS Base libraries
+vmc_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+#===========================
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/iocs/vmcIOC/vmcApp/src/Makefile
+++ b/iocs/vmcIOC/vmcApp/src/Makefile
@@ -16,11 +16,13 @@ DBD += vmc.dbd
 vmc_DBD += base.dbd
 
 # Include dbd files from all support applications:
+vmc_DBD += asyn.dbd drvAsynIPPort.dbd
 vmc_DBD += motorSupport.dbd
-vmc_DBD += vmc.dbd
+vmc_DBD += vmcSupport.dbd
 
 # Add all the support libraries needed by this IOC
 #vmc_LIBS += xxx
+vmc_LIBS += asyn
 vmc_LIBS += motor
 vmc_LIBS += vmc
 #!vmc_LIBS += softMotor

--- a/iocs/vmcIOC/vmcApp/src/vmcMain.cpp
+++ b/iocs/vmcIOC/vmcApp/src/vmcMain.cpp
@@ -1,0 +1,23 @@
+/* vmcMain.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {    
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/vmcApp/src/Makefile
+++ b/vmcApp/src/Makefile
@@ -13,7 +13,9 @@ LIBRARY_IOC += vmc
 # xxxRecord.h will be created from xxxRecord.dbd
 #DBDINC += xxxRecord
 # install vmc.dbd into <top>/dbd
-DBD += vmc.dbd
+DBD += vmcSupport.dbd
+
+vmcSupport_DBD += vmc.dbd
 
 # specify all source files to be compiled and added to the library
 vmc_SRCS += vmcDriver.cpp


### PR DESCRIPTION
Added an example IOC in the style of areaDetector modules (the IOC is a standalone directory that can be copied and built outside of the motorVMC dir).