### PR TITLE
Pass the P macro when vmc.substitutions is loaded

### DIFF
--- a/iocs/vmcIOC/iocBoot/iocvmc/vmc.cmd
+++ b/iocs/vmcIOC/iocBoot/iocvmc/vmc.cmd
@@ -20,8 +20,8 @@ asynOctetSetOutputEos("VMC_ETH",0,"\r")
 dbLoadRecords("$(MOTOR)/motorApp/Db/asyn_motor.db","P=$(PREFIX),M=m1,DTYP=asynMotor,PORT=VMC1,ADDR=0,DESC=X,EGU=mm,DIR=Pos,VELO=1,VBAS=.1,ACCL=.2,BDST=0,BVEL=1,BACC=.2,MRES=.0025,PREC=4,DHLM=100,DLLM=-100,INIT=")
 dbLoadRecords("$(MOTOR)/motorApp/Db/asyn_motor.db","P=$(PREFIX),M=m2,DTYP=asynMotor,PORT=VMC1,ADDR=1,DESC=Y,EGU=mm,DIR=Pos,VELO=1,VBAS=.1,ACCL=.2,BDST=0,BVEL=1,BACC=.2,MRES=.0025,PREC=4,DHLM=100,DLLM=-100,INIT=")
 dbLoadRecords("$(MOTOR)/motorApp/Db/asyn_motor.db","P=$(PREFIX),M=m3,DTYP=asynMotor,PORT=VMC1,ADDR=2,DESC=Z,EGU=mm,DIR=Pos,VELO=1,VBAS=.1,ACCL=.2,BDST=0,BVEL=1,BACC=.2,MRES=.0025,PREC=4,DHLM=100,DLLM=-100,INIT=")
-# If a substitutions file is used, the "P" macro needs to be modified by hand
-#!dbLoadTemplate("vmc.substitutions")
+# The dbLoadTemplate approach is a cleaner way to load multiple database instances
+#!dbLoadTemplate("vmc.substitutions", "P=$(PREFIX)")
 
 # VirtualMotorController(
 #    portName          The name of the asyn port that will be created for this driver

--- a/iocs/vmcIOC/iocBoot/iocvmc/vmc.substitutions
+++ b/iocs/vmcIOC/iocBoot/iocvmc/vmc.substitutions
@@ -1,13 +1,14 @@
+# Note: the P macro is omitted below because it is passed to dbLoadTemplates
 file "$(TOP)/db/asyn_motor.db"
 {
 pattern
-{P,     N,   M,       DTYP,         PORT,  ADDR,  DESC,          EGU, DIR,  VELO,  VBAS,  ACCL,  BDST,  BVEL,  BACC,  MRES,  PREC,  DHLM,  DLLM,  INIT}
-{vmc:,  1,  "m$(N)",  "asynMotor",  VMC1,  0,	  "motor $(N)",  mm,  Pos,  1,     .1,    .2,	 0,	1,     .2,    0.0025,  4,     100,   -100,  ""}
-{vmc:,  2,  "m$(N)",  "asynMotor",  VMC1,  1,	  "motor $(N)",  mm,  Pos,  1,     .1,    .2,	 0,	1,     .2,    0.0025,  4,     100,   -100,  ""}
-{vmc:,  3,  "m$(N)",  "asynMotor",  VMC1,  2,	  "motor $(N)",  mm,  Pos,  1,     .1,    .2,	 0,	1,     .2,    0.0025,  4,     100,   -100,  ""}
-{vmc:,  4,  "m$(N)",  "asynMotor",  VMC1,  3,     "motor $(N)",  deg, Pos,  1,     .1,    .2,    0,	1,     .2,    0.01,    4,     100,   -100,  ""}
-{vmc:,  5,  "m$(N)",  "asynMotor",  VMC1,  4,     "motor $(N)",  deg, Pos,  1,     .1,    .2,    0,	1,     .2,    0.01,    4,     100,   -100,  ""}
-{vmc:,  6,  "m$(N)",  "asynMotor",  VMC1,  5,     "motor $(N)",  deg, Pos,  1,     .1,    .2,    0,	1,     .2,    0.01,    4,     100,   -100,  ""}
-{vmc:,  7,  "m$(N)",  "asynMotor",  VMC1,  6,     "motor $(N)",  deg, Pos,  1,     .1,    .2,    0,	1,     .2,    0.01,    4,     100,   -100,  ""}
-{vmc:,  8,  "m$(N)",  "asynMotor",  VMC1,  7,     "motor $(N)",  deg, Pos,  1,     .1,    .2,    0,	1,     .2,    0.01,    4,     100,   -100,  ""}
+{N,   M,       DTYP,         PORT,  ADDR,  DESC,          EGU, DIR,  VELO,  VBAS,  ACCL,  BDST,  BVEL,  BACC,  MRES,  PREC,  DHLM,  DLLM,  INIT}
+{1,  "m$(N)",  "asynMotor",  VMC1,  0,     "motor $(N)",  mm,  Pos,  1,     .1,    .2,    0,     1,     .2,    0.0025,  4,     100,   -100,  ""}
+{2,  "m$(N)",  "asynMotor",  VMC1,  1,     "motor $(N)",  mm,  Pos,  1,     .1,    .2,    0,     1,     .2,    0.0025,  4,     100,   -100,  ""}
+{3,  "m$(N)",  "asynMotor",  VMC1,  2,     "motor $(N)",  mm,  Pos,  1,     .1,    .2,    0,     1,     .2,    0.0025,  4,     100,   -100,  ""}
+{4,  "m$(N)",  "asynMotor",  VMC1,  3,     "motor $(N)",  deg, Pos,  1,     .1,    .2,    0,     1,     .2,    0.01,    4,     100,   -100,  ""}
+{5,  "m$(N)",  "asynMotor",  VMC1,  4,     "motor $(N)",  deg, Pos,  1,     .1,    .2,    0,     1,     .2,    0.01,    4,     100,   -100,  ""}
+{6,  "m$(N)",  "asynMotor",  VMC1,  5,     "motor $(N)",  deg, Pos,  1,     .1,    .2,    0,     1,     .2,    0.01,    4,     100,   -100,  ""}
+{7,  "m$(N)",  "asynMotor",  VMC1,  6,     "motor $(N)",  deg, Pos,  1,     .1,    .2,    0,     1,     .2,    0.01,    4,     100,   -100,  ""}
+{8,  "m$(N)",  "asynMotor",  VMC1,  7,     "motor $(N)",  deg, Pos,  1,     .1,    .2,    0,     1,     .2,    0.01,    4,     100,   -100,  ""}
 }


### PR DESCRIPTION
Pass the P macro when vmc.substitutions is loaded so the substitutions file doesn't need to be modified when the prefix changes.